### PR TITLE
Use Popen.terminate() instead of Popen.kill()

### DIFF
--- a/taskrun/ClusterTask.py
+++ b/taskrun/ClusterTask.py
@@ -241,7 +241,7 @@ class ClusterTask(Task):
   def kill(self):
     """
     See Task.kill()
-    This implementation calls subprocess.kill()
+    This implementation calls Popen.terminate()
     """
 
     self.killed = True
@@ -250,6 +250,6 @@ class ClusterTask(Task):
     #  completed
     if self._proc:
       try:
-        self._proc.kill()
+        self._proc.terminate()
       except ProcessLookupError:
         pass

--- a/taskrun/ProcessTask.py
+++ b/taskrun/ProcessTask.py
@@ -187,7 +187,7 @@ class ProcessTask(Task):
   def kill(self):
     """
     See Task.kill()
-    This implementation calls subprocess.kill()
+    This implementation calls Popen.terminate()
     """
 
     self.killed = True
@@ -196,6 +196,6 @@ class ProcessTask(Task):
     #  completed
     if self._proc:
       try:
-        self._proc.kill()
+        self._proc.terminate()
       except ProcessLookupError:
         pass


### PR DESCRIPTION
kill() sends SIGKILL which does not clean up resources.
terminate() sends SIGTERM which is nicer.