### PR TITLE
Catch all exceptions thrown by a Task

### DIFF
--- a/taskrun/Task.py
+++ b/taskrun/Task.py
@@ -231,7 +231,7 @@ class Task(threading.Thread):
       # try to execute
       try:
         self._errors = self.execute()
-      except RuntimeError as ex:
+      except Exception as ex:
         self._errors = ex
 
       # report to the task manager

--- a/test/test_failures.py
+++ b/test/test_failures.py
@@ -622,3 +622,10 @@ class FailuresTestCase(unittest.TestCase):
     self.make_graph(tm)
     tm.run_tasks()
     self.assertTrue(ob.ok())
+
+  def test_exception(self):
+    ob = OrderCheckObserver(['@t1', '+t1', '!t1'])
+    tm = taskrun.TaskManager(observers=[ob], failure_mode='aggressive_fail')
+    t1 = taskrun.FunctionTask(tm, 't1', lambda: 1/0)
+    tm.run_tasks()
+    self.assertTrue(ob.ok())


### PR DESCRIPTION
Otherwise the Task dies without notifying the manager of its death, so
the manager waits forever.

I ran into this in the wild when taskrun ran out of file descriptors.
subprocess.Popen() throws an OSError (which inherits from Exceptions,
but not RuntimeError) in this case.