### PR TITLE
Implemented proper signal handling.

### DIFF
--- a/taskrun/ClusterTask.py
+++ b/taskrun/ClusterTask.py
@@ -224,7 +224,6 @@ class ClusterTask(Task):
         cmd.extend(['-e', os.devnull])
       cmd.append(self._command)
       return ' '.join(cmd)
-    # programmer error
     else:
       assert False
 
@@ -243,9 +242,6 @@ class ClusterTask(Task):
       self._proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True,
         start_new_session=True)
-
-      # ensures that the subprocess is in a different group
-      assert os.getsid(self._proc.pid) != os.getsid(os.getpid())
 
     # wait for the process to finish, collect output
     self.stdout, self.stderr = self._proc.communicate()

--- a/taskrun/ClusterTask.py
+++ b/taskrun/ClusterTask.py
@@ -264,7 +264,8 @@ class ClusterTask(Task):
     """
 
     with self._lock:
-      if not self.killed:
+      # Don't kill if already completed or already killed
+      if self.returncode is None and not self.killed:
         self.killed = True
         # there is a chance the proc hasn't been created yet
         if self._proc is not None:

--- a/taskrun/CpuTimeResource.py
+++ b/taskrun/CpuTimeResource.py
@@ -77,11 +77,10 @@ class CpuTimeResource(Resource):
 
     # enforce CPU time limit on the ProcessTask
     if isinstance(task, ProcessTask):
-      if False:  # use later when Python subprocess is smarter
-        task.add_prefunc(lambda: (limit_cputime(secs)))
-      else:
-        assert int(secs) > 0
-        task.command = 'ulimit -t {} && {}'.format(int(secs), task.command)
+      # TODO(nicmcd): use the following when Python subprocess is fixed
+      # task.add_prefunc(lambda: (limit_cputime(secs)))
+      assert int(secs) > 0
+      task.command = 'ulimit -t {} && {}'.format(int(secs), task.command)
 
     return True
 

--- a/taskrun/CpuTimeResource.py
+++ b/taskrun/CpuTimeResource.py
@@ -77,7 +77,11 @@ class CpuTimeResource(Resource):
 
     # enforce CPU time limit on the ProcessTask
     if isinstance(task, ProcessTask):
-      task.add_prefunc(lambda: (limit_cputime(secs)))
+      if False:  # use later when Python subprocess is smarter
+        task.add_prefunc(lambda: (limit_cputime(secs)))
+      else:
+        assert int(secs) > 0
+        task.command = 'ulimit -t {} && {}'.format(int(secs), task.command)
 
     return True
 

--- a/taskrun/FunctionTask.py
+++ b/taskrun/FunctionTask.py
@@ -57,6 +57,7 @@ class FunctionTask(Task):
     self._func = func
     self._args = args
     self._kwargs = kwargs
+    self._done = False
 
   def describe(self):
     """
@@ -71,7 +72,9 @@ class FunctionTask(Task):
     See Task.execute()
     """
 
-    return self._func(*self._args, **self._kwargs)
+    self._done = True
+    res = self._func(*self._args, **self._kwargs)
+    return res
 
   def kill(self):
     """
@@ -79,4 +82,5 @@ class FunctionTask(Task):
     This implementation ignores this because it can't kill the function
     call once it has already been made.
     """
-    self.killed = True
+    if not self._done:
+      self.killed = True

--- a/taskrun/MemoryResource.py
+++ b/taskrun/MemoryResource.py
@@ -62,8 +62,12 @@ class MemoryResource(CounterResource):
     # if this is a ProcessTask, enforce memory limit
     if isinstance(task, ProcessTask):
       assert uses > 0.0, 'ProcessTasks must use some memory!'
-      membytes = int(uses * 1024 * 1024 * 1024)
-      task.add_prefunc(lambda: (limit_mem(membytes)))
+      if False:  # use later when Python subprocess is smarter
+        membytes = int(uses * 1024 * 1024 * 1024)
+        task.add_prefunc(lambda: (limit_mem(membytes)))
+      else:
+        memkbytes = int(uses * 1024 * 1024)
+        task.command = 'ulimit -v {} && {}'.format(memkbytes, task.command)
 
   def current_available_memory_gib():
     """

--- a/taskrun/MemoryResource.py
+++ b/taskrun/MemoryResource.py
@@ -62,12 +62,11 @@ class MemoryResource(CounterResource):
     # if this is a ProcessTask, enforce memory limit
     if isinstance(task, ProcessTask):
       assert uses > 0.0, 'ProcessTasks must use some memory!'
-      if False:  # use later when Python subprocess is smarter
-        membytes = int(uses * 1024 * 1024 * 1024)
-        task.add_prefunc(lambda: (limit_mem(membytes)))
-      else:
-        memkbytes = int(uses * 1024 * 1024)
-        task.command = 'ulimit -v {} && {}'.format(memkbytes, task.command)
+      # TODO(nicmcd): use the following when Python subprocess is fixed
+      # membytes = int(uses * 1024 * 1024 * 1024)
+      # task.add_prefunc(lambda: (limit_mem(membytes)))
+      memkbytes = int(uses * 1024 * 1024)
+      task.command = 'ulimit -v {} && {}'.format(memkbytes, task.command)
 
   def current_available_memory_gib():
     """

--- a/taskrun/NopTask.py
+++ b/taskrun/NopTask.py
@@ -51,6 +51,7 @@ class NopTask(Task):
     """
 
     super(NopTask, self).__init__(manager, name)
+    self._done = False
 
   def describe(self):
     """
@@ -62,11 +63,12 @@ class NopTask(Task):
     """
     See Task.execute()
     """
-    pass
+    self._done = True
 
   def kill(self):
     """
     See Task.kill()
     This implementation ignores this because there is nothing to kill!
     """
-    self.killed = True
+    if not self._done:
+      self.killed = True

--- a/taskrun/ProcessTask.py
+++ b/taskrun/ProcessTask.py
@@ -204,7 +204,8 @@ class ProcessTask(Task):
     """
 
     with self._lock:
-      if not self.killed:
+      # Don't kill if already completed or already killed
+      if self.returncode is None and not self.killed:
         self.killed = True
         # there is a chance the proc hasn't been created yet
         if self._proc is not None:

--- a/taskrun/ProcessTask.py
+++ b/taskrun/ProcessTask.py
@@ -32,7 +32,11 @@
 # Python 3 compatibility
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
+import os
+import signal
 import subprocess
+import threading
+import time
 
 from .Task import Task
 
@@ -59,8 +63,10 @@ class ProcessTask(Task):
     self._stderr_file = None
     self.stdout = None
     self.stderr = None
+    self.retcode = None
     self._proc = None
     self._prefuncs = []
+    self._lock = threading.Lock()
 
   @property
   def command(self):
@@ -123,7 +129,9 @@ class ProcessTask(Task):
     Args:
       func (callable) : a callable to be executed
     """
-    self._prefuncs.append(func)
+    raise NotImplementedError('ProcessTask does not yet support pre-execution '
+                              'functions due to Python subprocess limitations.')
+    #self._prefuncs.append(func)
 
   def describe(self):
     """
@@ -142,34 +150,34 @@ class ProcessTask(Task):
     See Task.execute()
     """
 
-    # If we're killed at this point, don't bother starting a new process.
-    if self.killed:
-      return None
+    with self._lock:
+      # If we're killed at this point, don't bother starting a new process.
+      if self.killed:
+        return None
 
-    # format stdout and stderr outputs
-    if self._stdout_file:
-      stdout_fd = open(self._stdout_file, 'w')
-    else:
-      stdout_fd = subprocess.PIPE
-    if self._stderr_file:
-      if self._stderr_file.lower() == 'stdout':
-        stderr_fd = subprocess.STDOUT
-      elif self._stderr_file == self._stdout_file:
-        stderr_fd = stdout_fd
+      # format stdout and stderr outputs
+      if self._stdout_file:
+        stdout_fd = open(self._stdout_file, 'w')
       else:
-        stderr_fd = open(self._stderr_file, 'w')
-    else:
-      stderr_fd = subprocess.PIPE
+        stdout_fd = subprocess.PIPE
+      if self._stderr_file:
+        if self._stderr_file.lower() == 'stdout':
+          stderr_fd = subprocess.STDOUT
+        elif self._stderr_file == self._stdout_file:
+          stderr_fd = stdout_fd
+        else:
+          stderr_fd = open(self._stderr_file, 'w')
+      else:
+        stderr_fd = subprocess.PIPE
 
-    # execute the task command
-    self._proc = subprocess.Popen(
-      self._command, stdout=stdout_fd, stderr=stderr_fd, shell=True,
-      preexec_fn=lambda: ([func() for func in self._prefuncs]))
+      # executes the task command
+      self._proc = subprocess.Popen(
+        self._command, stdout=stdout_fd, stderr=stderr_fd, shell=True,
+        start_new_session=True)#,
+        #preexec_fn=lambda: ([func() for func in self._prefuncs]))
 
-    # We could be killed while we're starting the process above. In this case,
-    # terminate the new process, but still clean up.
-    if self.killed:
-      self._proc.terminate()
+      # ensures that the subprocess is in a different group
+      assert os.getsid(self._proc.pid) != os.getsid(os.getpid())
 
     # wait for the process to finish, collect output
     self.stdout, self.stderr = self._proc.communicate()
@@ -187,11 +195,11 @@ class ProcessTask(Task):
       stderr_fd.close()
 
     # check the return code
-    ret = self._proc.returncode
-    if ret == 0:
+    self.retcode = self._proc.returncode
+    if self.retcode == 0:
       return None
     else:
-      return ret
+      return self.retcode
 
   def kill(self):
     """
@@ -199,12 +207,12 @@ class ProcessTask(Task):
     This implementation calls Popen.terminate()
     """
 
-    self.killed = True
-
-    # there is a chance the proc hasn't been created yet or has already
-    #  completed
-    if self._proc:
-      try:
-        self._proc.terminate()
-      except ProcessLookupError:
-        pass
+    with self._lock:
+      if not self.killed:
+        self.killed = True
+        # there is a chance the proc hasn't been created yet
+        if self._proc is not None:
+          try:
+            self._proc.terminate()
+          except ProcessLookupError as ex:
+            pass

--- a/taskrun/ProcessTask.py
+++ b/taskrun/ProcessTask.py
@@ -63,7 +63,7 @@ class ProcessTask(Task):
     self._stderr_file = None
     self.stdout = None
     self.stderr = None
-    self.retcode = None
+    self.returncode = None
     self._proc = None
     self._prefuncs = []
     self._lock = threading.Lock()
@@ -173,11 +173,7 @@ class ProcessTask(Task):
       # executes the task command
       self._proc = subprocess.Popen(
         self._command, stdout=stdout_fd, stderr=stderr_fd, shell=True,
-        start_new_session=True)#,
-        #preexec_fn=lambda: ([func() for func in self._prefuncs]))
-
-      # ensures that the subprocess is in a different group
-      assert os.getsid(self._proc.pid) != os.getsid(os.getpid())
+        start_new_session=True)
 
     # wait for the process to finish, collect output
     self.stdout, self.stderr = self._proc.communicate()
@@ -195,11 +191,11 @@ class ProcessTask(Task):
       stderr_fd.close()
 
     # check the return code
-    self.retcode = self._proc.returncode
-    if self.retcode == 0:
+    self.returncode = self._proc.returncode
+    if self.returncode == 0:
       return None
     else:
-      return self.retcode
+      return self.returncode
 
   def kill(self):
     """

--- a/taskrun/Task.py
+++ b/taskrun/Task.py
@@ -222,7 +222,7 @@ class Task(threading.Thread):
 
   def run(self):
     """
-    This either executes the task of performs the bypass.
+    This either executes the task or performs the bypass.
     """
 
     # execute the task

--- a/taskrun/Task.py
+++ b/taskrun/Task.py
@@ -255,10 +255,12 @@ class Task(threading.Thread):
 
   def execute(self):
     """
-    Executes this task
+    Executes this task.
+
+    WARNING: subclass implementations
 
     Returns:
-      (None or errors) : None for success, errors on failure
+      (None or errors) : None for success, errors on failure,
     """
     raise NotImplementedError('subclasses should override this!')
 
@@ -267,6 +269,7 @@ class Task(threading.Thread):
     Kills this task. This may or may not be possible, but when it is, it must be
     immediately carryied out.
 
-    WARNING: subclass implementations must set self.killed = True
+    WARNING: subclass implementations must set self.killed = True if the process
+    was actually killed.
     """
     raise NotImplementedError('subclasses should override this!')

--- a/taskrun/TaskManager.py
+++ b/taskrun/TaskManager.py
@@ -372,12 +372,13 @@ class TaskManager(object):
     Sets the signal handlers for SIGINT and SIGTERM to gracefully shutdown when
     received. SIGINT also includes a 3 seconds guard window.
     """
-    ignore_signal = [False]  # in a list to behave as a reference
+    ignore_signal = False  # in a list to behave as a reference
     def handler(signum, frame):
       # Ignores signal if this function is already handling a signal.
-      if ignore_signal[0]:
+      nonlocal ignore_signal
+      if ignore_signal:
         return
-      ignore_signal[0] = True
+      ignore_signal = True
 
       # Kills the process if the task manager's known pid does not match the pid
       # of this process. This is for the case where a task uses subprocess to
@@ -401,7 +402,7 @@ class TaskManager(object):
         # that may or may not have the condition variable acquired. A separate
         # thread allows this to behave just like a failing task.
         threading.Thread(target=self._terminate).start()
-      ignore_signal[0] = False
+      ignore_signal = False
 
     # Installs 'handler' as the signal handler for SIGINT and SIGTERM
     signal.signal(signal.SIGINT, handler)

--- a/taskrun/TaskManager.py
+++ b/taskrun/TaskManager.py
@@ -263,7 +263,7 @@ class TaskManager(object):
     with self._condition_variable:
       # handle failure based on failure mode
       if self._failure_mode is FailureMode.AGGRESSIVE_FAIL:
-        self._kill_running(task)
+        self._kill_running()
         self._clear_waiting_and_ready()
       elif self._failure_mode is FailureMode.PASSIVE_FAIL:
         self._clear_waiting_and_ready()
@@ -284,19 +284,15 @@ class TaskManager(object):
       # clean up the task
       self._task_done(task)
 
-  def _kill_running(self, task):
+  def _kill_running(self):
     """
-    Kills all running tasks except for the specified task.
-
-    Args:
-      task (Task) : A task that should be skipped, or None
+    Kills all running tasks
     """
     # kill all the currently running tasks
     if not self._killed:
       self._killed = True
-      for running_task in self._running_tasks:
-        if running_task is not task:
-          running_task.kill()
+      for task in self._running_tasks:
+        task.kill()
 
   def _clear_waiting_and_ready(self):
     """
@@ -363,7 +359,7 @@ class TaskManager(object):
     assert self._running is True
     self._failed = True
     with self._condition_variable:
-      self._kill_running(None)
+      self._kill_running()
       self._clear_waiting_and_ready()
       self._condition_variable.notify()
 

--- a/taskrun/TaskManager.py
+++ b/taskrun/TaskManager.py
@@ -394,8 +394,7 @@ class TaskManager(object):
       self._last_signal_time = now
       if signum == signal.SIGTERM or delta < 3.0:
         # Resets signal handlers to default
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
-        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        self._reset_signal_handlers()
 
         # Create a new thread to perform the termination. A separate thread is
         # needed because this signal handler is running within the main thread

--- a/taskrun/TaskManager.py
+++ b/taskrun/TaskManager.py
@@ -360,7 +360,7 @@ class TaskManager(object):
 
   def _terminate(self):
     """
-    This signal the main thread for termination.
+    Executes the procedure for graceful forced shutdown.
     """
     self._failure_mode = FailureMode.AGGRESSIVE_FAIL
     self._task_error(None, None)

--- a/test/test_failures.py
+++ b/test/test_failures.py
@@ -625,11 +625,13 @@ class FailuresTestCase(unittest.TestCase):
     self.assertTrue(ob.ok())
 
   def test_exception(self):
-    ob = OrderCheckObserver(['@t1', '+t1', '!t1'])
-    tm = taskrun.TaskManager(observers=[ob], failure_mode='aggressive_fail')
-    t1 = taskrun.FunctionTask(tm, 't1', lambda: 1/0)
-    tm.run_tasks()
-    self.assertTrue(ob.ok())
+    for mode in ['aggressive_fail', 'passive_fail', 'active_continue',
+                 'blind_continue']:
+      ob = OrderCheckObserver(['@t1', '+t1', '!t1'], verbose=False)
+      tm = taskrun.TaskManager(observers=[ob], failure_mode=mode)
+      t1 = taskrun.FunctionTask(tm, 't1', lambda: 1/0)
+      tm.run_tasks()
+      self.assertTrue(ob.ok())
 
   def test_kill_race(self):
     rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 200))

--- a/test/test_signals.py
+++ b/test/test_signals.py
@@ -1,0 +1,153 @@
+"""
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * - Neither the name of prim nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+"""
+
+# Python 3 compatibility
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from .OrderCheckObserver import OrderCheckObserver
+import os
+import unittest
+import signal
+import subprocess
+import taskrun
+import threading
+import time
+
+
+def send_signal(pid, sig, sleep):
+  if sig:
+    cmd = ['kill', '-{}'.format(int(sig)), str(pid)]
+  else:
+    cmd = ['kill', str(pid)]
+  time.sleep(sleep)
+  subprocess.run(cmd, check=False)
+
+class SignalTestCase(unittest.TestCase):
+
+  def test_sigint_one_ignored(self):
+    ob = OrderCheckObserver(
+      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
+       '+t5', '-t5', '+t6', '-t6', '+t7', '-t7', '+t8', '-t8', '+t9', '-t9'],
+      verbose=False)
+    rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
+    tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
+                             failure_mode='blind_continue')
+    tasks = []
+    for tid in range(10):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.2'))
+    pid = os.getpid()
+    threading.Thread(
+      target=send_signal, args=(pid, signal.SIGINT, 1.1)).start()
+    res = tm.run_tasks()
+    self.assertTrue(res)
+    self.assertTrue(ob.ok())
+
+  def test_sigint_two_ignored(self):
+    ob = OrderCheckObserver(
+      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
+       '+t5', '-t5', '+t6', '-t6', '+t7', '-t7', '+t8', '-t8', '+t9', '-t9'],
+      verbose=False)
+    rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
+    tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
+                             failure_mode='blind_continue')
+    tasks = []
+    for tid in range(10):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.4'))
+    pid = os.getpid()
+    threading.Thread(
+      target=send_signal, args=(pid, signal.SIGINT, 0.150)).start()
+    threading.Thread(
+      target=send_signal, args=(pid, signal.SIGINT, 3.550)).start()
+    res = tm.run_tasks()
+    self.assertTrue(res)
+    self.assertTrue(ob.ok())
+
+
+  def test_sigint_two_accepted(self):
+    ob = OrderCheckObserver(
+      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
+       '+t5', '$t5'], verbose=False)
+    rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
+    tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
+                             failure_mode='blind_continue')
+    tasks = []
+    for tid in range(10):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.2'))
+    pid = os.getpid()
+    threading.Thread(
+      target=send_signal, args=(pid, signal.SIGINT, 0.1)).start()
+    threading.Thread(
+      target=send_signal, args=(pid, signal.SIGINT, 1.1)).start()
+    res = tm.run_tasks()
+    self.assertFalse(res)
+    self.assertTrue(ob.ok())
+
+  def test_sigterm(self):
+    ob = OrderCheckObserver(
+      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
+       '+t5', '$t5'], verbose=False)
+    rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
+    tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
+                             failure_mode='blind_continue')
+    tasks = []
+    for tid in range(10):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.2'))
+    pid = os.getpid()
+    threading.Thread(
+      target=send_signal, args=(pid, signal.SIGTERM, 1.1)).start()
+    res = tm.run_tasks()
+    self.assertFalse(res)
+    self.assertTrue(ob.ok())
+
+  def test_sigint_sigterm(self):
+    ob = OrderCheckObserver(
+      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
+       '+t5', '-t5', '+t6', '-t6', '+t7', '-t7', '+t8', '$t8'],
+      verbose=False)
+    rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
+    tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
+                             failure_mode='blind_continue')
+    tasks = []
+    for tid in range(10):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.4'))
+    pid = os.getpid()
+    threading.Thread(
+      target=send_signal, args=(pid, signal.SIGINT, 0.150)).start()
+    threading.Thread(
+      target=send_signal, args=(pid, signal.SIGTERM, 3.550)).start()
+    res = tm.run_tasks()
+    self.assertFalse(res)
+    self.assertTrue(ob.ok())

--- a/test/test_signals.py
+++ b/test/test_signals.py
@@ -54,35 +54,33 @@ class SignalTestCase(unittest.TestCase):
 
   def test_sigint_one_ignored(self):
     ob = OrderCheckObserver(
-      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
-       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
-       '+t5', '-t5', '+t6', '-t6', '+t7', '-t7', '+t8', '-t8', '+t9', '-t9'],
+      ['@t0', '@t1', '@t2', '@t3',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3'],
       verbose=False)
     rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
     tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
                              failure_mode='blind_continue')
     tasks = []
-    for tid in range(10):
-      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.2'))
+    for tid in range(4):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.5'))
     pid = os.getpid()
     threading.Thread(
-      target=send_signal, args=(pid, signal.SIGINT, 1.1)).start()
+      target=send_signal, args=(pid, signal.SIGINT, 1.25)).start()
     res = tm.run_tasks()
     self.assertTrue(res)
     self.assertTrue(ob.ok())
 
   def test_sigint_two_ignored(self):
     ob = OrderCheckObserver(
-      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
-       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
-       '+t5', '-t5', '+t6', '-t6', '+t7', '-t7', '+t8', '-t8', '+t9', '-t9'],
+      ['@t0', '@t1', '@t2', '@t3',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3'],
       verbose=False)
     rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
     tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
                              failure_mode='blind_continue')
     tasks = []
-    for tid in range(10):
-      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.4'))
+    for tid in range(4):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 1.0'))
     pid = os.getpid()
     threading.Thread(
       target=send_signal, args=(pid, signal.SIGINT, 0.150)).start()
@@ -95,57 +93,56 @@ class SignalTestCase(unittest.TestCase):
 
   def test_sigint_two_accepted(self):
     ob = OrderCheckObserver(
-      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
-       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
-       '+t5', '$t5'], verbose=False)
+      ['@t0', '@t1', '@t2', '@t3',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '$t2',],
+      verbose=False)
     rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
     tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
                              failure_mode='blind_continue')
     tasks = []
-    for tid in range(10):
-      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.2'))
+    for tid in range(4):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.5'))
     pid = os.getpid()
     threading.Thread(
-      target=send_signal, args=(pid, signal.SIGINT, 0.1)).start()
+      target=send_signal, args=(pid, signal.SIGINT, 0.25)).start()
     threading.Thread(
-      target=send_signal, args=(pid, signal.SIGINT, 1.1)).start()
+      target=send_signal, args=(pid, signal.SIGINT, 1.25)).start()
     res = tm.run_tasks()
     self.assertFalse(res)
     self.assertTrue(ob.ok())
 
   def test_sigterm(self):
     ob = OrderCheckObserver(
-      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
-       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
-       '+t5', '$t5'], verbose=False)
+      ['@t0', '@t1', '@t2', '@t3',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '$t2'],
+      verbose=False)
     rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
     tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
                              failure_mode='blind_continue')
     tasks = []
-    for tid in range(10):
-      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.2'))
+    for tid in range(4):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.5'))
     pid = os.getpid()
     threading.Thread(
-      target=send_signal, args=(pid, signal.SIGTERM, 1.1)).start()
+      target=send_signal, args=(pid, signal.SIGTERM, 1.25)).start()
     res = tm.run_tasks()
     self.assertFalse(res)
     self.assertTrue(ob.ok())
 
   def test_sigint_sigterm(self):
     ob = OrderCheckObserver(
-      ['@t0', '@t1', '@t2', '@t3', '@t4', '@t5', '@t6', '@t7', '@t8', '@t9',
-       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '-t3', '+t4', '-t4',
-       '+t5', '-t5', '+t6', '-t6', '+t7', '-t7', '+t8', '$t8'],
+      ['@t0', '@t1', '@t2', '@t3',
+       '+t0', '-t0', '+t1', '-t1', '+t2', '-t2', '+t3', '$t3'],
       verbose=False)
     rm = taskrun.ResourceManager(taskrun.CounterResource('slots', 1, 1))
     tm = taskrun.TaskManager(resource_manager=rm, observers=[ob],
                              failure_mode='blind_continue')
     tasks = []
-    for tid in range(10):
-      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 0.4'))
+    for tid in range(4):
+      tasks.append(taskrun.ProcessTask(tm, 't{}'.format(tid), 'sleep 1.0'))
     pid = os.getpid()
     threading.Thread(
-      target=send_signal, args=(pid, signal.SIGINT, 0.150)).start()
+      target=send_signal, args=(pid, signal.SIGINT, 0.100)).start()
     threading.Thread(
       target=send_signal, args=(pid, signal.SIGTERM, 3.550)).start()
     res = tm.run_tasks()


### PR DESCRIPTION
SIGINT and SIGTERM are now properly handled. SIGTERM is acted upon immediately whereas SIGINT includes a 3 second guard where the use must send two SIGINTs within a 3 second window to activate termination.

Due to subprocess limitations, this removes the support for
preexec_fn on ProcessTasks. Until Python fixes the problem,
MemoryResource and CpuTimeResource have been altered to prepend
ulimit controls to the command.